### PR TITLE
Implement PartialEq on V2Vector / V3Vector.

### DIFF
--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -11,7 +11,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 /// CVSS vector version v2
 ///
 /// ```
@@ -228,6 +228,18 @@ mod tests {
             vector.availability_requirement,
             env::AvailabilityRequirement::Medium
         );
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let cvss_str = "AV:A/AC:L/Au:S/C:P/I:P/A:C/E:POC/RL:W/RC:UR/CDP:LM/TD:H/CR:M/IR:M/AR:M";
+        let vector = V2Vector::from_str(cvss_str).unwrap();
+        let other = "AV:A/AC:L/Au:S/C:P/I:P/A:C/E:POC/RL:W/RC:UR/CDP:LM/TD:H/CR:M/IR:M/AR:M";
+        let other_vector = V2Vector::from_str(other).unwrap();
+        let different_str = "AV:A/AC:L/Au:S/C:P/I:C/A:C/E:POC/RL:W/RC:UR/CDP:LM/TD:H/CR:M/IR:M/AR:M";
+        let different_vector = V2Vector::from_str(different_str).unwrap();
+        assert_eq!(vector, other_vector);
+        assert_ne!(vector, different_vector);
     }
 
     #[test]

--- a/src/v3/mod.rs
+++ b/src/v3/mod.rs
@@ -42,7 +42,7 @@ impl AsStr for MinorVersion {
 
 #[rustfmt::skip]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 /// CVSS vector version 3.0/3.1
 /// 
 /// ```
@@ -263,6 +263,15 @@ mod tests {
             vector.report_confidence,
             temporal::ReportConfidence::Confirmed
         );
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let vector = V3Vector::from_str("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N").unwrap();
+        let other_vector = V3Vector::from_str("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N").unwrap();
+        let different_vector = V3Vector::from_str("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N").unwrap();
+        assert_eq!(vector, other_vector);
+        assert_ne!(vector, different_vector);
     }
 
     #[test]


### PR DESCRIPTION
This is just a simple change to implement PartialEq on the two vector
structs so they can be compared in structs which contain them. Includes
tests for both `eq` and `ne`.